### PR TITLE
fixed: multiple definitions during linking step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION := 0.9.9
 
 CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
-LDFLAGS  ?=
+LDFLAGS  ?= -zmuldefs
 LDLIBS    = $(LDFLAGS) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama -lxcb-shape
 
 PREFIX    ?= /usr/local


### PR DESCRIPTION
When installing the patch, it didn't compile because there were errors when ld tried to link the files. The -zmuldefs flag fixed this behaviour.